### PR TITLE
Add deck info editing to live game and game edit page

### DIFF
--- a/apps/web/src/app/games/[id]/edit/actions.ts
+++ b/apps/web/src/app/games/[id]/edit/actions.ts
@@ -10,6 +10,9 @@ type PlayerUpdate = {
   isWinner: boolean;
   isFirstOut: boolean;
   eliminatedTurn: number | null;
+  commanderUsed1?: string | null;
+  commanderUsed2?: string | null;
+  bracketUsed?: number | null;
 };
 
 type UpdateGameInput = {
@@ -85,6 +88,15 @@ export async function updateGame(
           isWinner: player.isWinner,
           isFirstOut: player.isFirstOut,
           eliminatedTurn: player.eliminatedTurn,
+          ...(player.commanderUsed1 !== undefined && {
+            commanderUsed1: player.commanderUsed1,
+          }),
+          ...(player.commanderUsed2 !== undefined && {
+            commanderUsed2: player.commanderUsed2,
+          }),
+          ...(player.bracketUsed !== undefined && {
+            bracketUsed: player.bracketUsed,
+          }),
         },
       });
     }

--- a/apps/web/src/app/games/[id]/edit/edit-game-form.tsx
+++ b/apps/web/src/app/games/[id]/edit/edit-game-form.tsx
@@ -5,9 +5,15 @@ import { useRouter } from "next/navigation";
 import { updateGame, deleteGame } from "./actions";
 import {
   FORMAT_LABELS,
+  isCommanderFormat,
+  hasBrackets,
   type MtgFormat,
 } from "@/types/mtg";
 import { AlertMessage } from "@/components/alert-message";
+import {
+  PlayerDeckFields,
+  type PlayerDeckEdit,
+} from "@/components/player-deck-fields";
 
 type GamePlayer = {
   id: string;
@@ -23,6 +29,8 @@ type GamePlayer = {
   eliminatedTurn: number | null;
   user: { id: string; username: string } | null;
   playgroupPlayer: { id: string; name: string } | null;
+  deck: { id: string; name: string } | null;
+  playgroupPlayerDeck: { id: string; name: string } | null;
 };
 
 type Game = {
@@ -52,6 +60,9 @@ export function EditGameForm({ game }: Props) {
     new Date(game.playedAt).toISOString().slice(0, 16)
   );
 
+  const showDeckSection =
+    isCommanderFormat(game.format) || hasBrackets(game.format);
+
   // Player results
   const [players, setPlayers] = useState(
     game.players.map((p) => ({
@@ -64,10 +75,32 @@ export function EditGameForm({ game }: Props) {
     }))
   );
 
+  // Deck edits per player
+  const [deckEdits, setDeckEdits] = useState<Record<string, PlayerDeckEdit>>(
+    () => {
+      const initial: Record<string, PlayerDeckEdit> = {};
+      for (const p of game.players) {
+        initial[p.id] = {
+          commanderUsed1: p.commanderUsed1 || "",
+          commanderUsed2: p.commanderUsed2 || "",
+          bracketUsed: p.bracketUsed?.toString() || "",
+          saveAsNewDeck: false,
+        };
+      }
+      return initial;
+    }
+  );
+
   function getPlayerName(player: GamePlayer) {
     if (player.user) return player.user.username;
     if (player.playgroupPlayer) return player.playgroupPlayer.name;
     return player.guestName || "Unknown Player";
+  }
+
+  function getDeckDisplayName(player: GamePlayer): string | null {
+    if (player.deck) return player.deck.name;
+    if (player.playgroupPlayerDeck) return player.playgroupPlayerDeck.name;
+    return null;
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -80,13 +113,19 @@ export function EditGameForm({ game }: Props) {
         totalTurns,
         notes: notes || null,
         playedAt: new Date(playedAt),
-        players: players.map((p) => ({
-          id: p.id,
-          placement: p.placement,
-          isWinner: p.isWinner,
-          isFirstOut: p.isFirstOut,
-          eliminatedTurn: p.eliminatedTurn,
-        })),
+        players: players.map((p) => {
+          const de = deckEdits[p.id];
+          return {
+            id: p.id,
+            placement: p.placement,
+            isWinner: p.isWinner,
+            isFirstOut: p.isFirstOut,
+            eliminatedTurn: p.eliminatedTurn,
+            commanderUsed1: de?.commanderUsed1 || null,
+            commanderUsed2: de?.commanderUsed2 || null,
+            bracketUsed: de?.bracketUsed ? parseInt(de.bracketUsed) : null,
+          };
+        }),
       });
 
       if ("error" in result) {
@@ -311,6 +350,40 @@ export function EditGameForm({ game }: Props) {
             ))}
           </div>
         </div>
+
+        {/* Deck Info */}
+        {showDeckSection && (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+            <h2 className="text-lg font-semibold mb-2">Deck Info</h2>
+            <p className="text-xs text-zinc-500 mb-4">
+              Update commanders and brackets used in this game.
+            </p>
+
+            <div className="space-y-3">
+              {game.players.map((gp) => (
+                <PlayerDeckFields
+                  key={gp.id}
+                  playerId={gp.id}
+                  playerName={getPlayerName(gp)}
+                  format={game.format}
+                  deckName={getDeckDisplayName(gp)}
+                  edit={
+                    deckEdits[gp.id] || {
+                      commanderUsed1: "",
+                      commanderUsed2: "",
+                      bracketUsed: "",
+                      saveAsNewDeck: false,
+                    }
+                  }
+                  onChange={(edit) =>
+                    setDeckEdits((prev) => ({ ...prev, [gp.id]: edit }))
+                  }
+                  canSaveDeck={false}
+                />
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Actions */}
         <div className="flex items-center justify-between">

--- a/apps/web/src/app/games/play/end/page.tsx
+++ b/apps/web/src/app/games/play/end/page.tsx
@@ -3,6 +3,13 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useGame } from "@/contexts/game-context";
+import { isCommanderFormat, hasBrackets } from "@/types/mtg";
+import {
+  PlayerDeckFields,
+  type PlayerDeckEdit,
+} from "@/components/player-deck-fields";
+import { saveNewDeckFromGame } from "@/app/games/new/actions";
+import type { MtgFormat } from "@/types/mtg";
 
 export default function EndGameScreen() {
   const router = useRouter();
@@ -11,6 +18,29 @@ export default function EndGameScreen() {
   const [isDraw, setIsDraw] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const showDeckSection =
+    isCommanderFormat(state.format) || hasBrackets(state.format);
+
+  // Initialize deck edits from game state
+  const [deckEdits, setDeckEdits] = useState<Record<string, PlayerDeckEdit>>(
+    {}
+  );
+
+  useEffect(() => {
+    if (hydrated && hasActiveGame && Object.keys(deckEdits).length === 0) {
+      const initial: Record<string, PlayerDeckEdit> = {};
+      for (const p of state.players) {
+        initial[p.id] = {
+          commanderUsed1: p.commanderUsed1 || "",
+          commanderUsed2: p.commanderUsed2 || "",
+          bracketUsed: p.bracketUsed?.toString() || "",
+          saveAsNewDeck: false,
+        };
+      }
+      setDeckEdits(initial);
+    }
+  }, [hydrated, hasActiveGame, state.players, deckEdits]);
 
   useEffect(() => {
     if (hydrated && !hasActiveGame) {
@@ -21,7 +51,7 @@ export default function EndGameScreen() {
   if (!hydrated || !hasActiveGame) {
     return (
       <div className="min-h-screen bg-zinc-950 text-zinc-400 flex items-center justify-center">
-        Loading…
+        Loading...
       </div>
     );
   }
@@ -54,6 +84,72 @@ export default function EndGameScreen() {
 
     setSaving(true);
     try {
+      // Build per-player deck overrides and handle "save as new deck"
+      const playerOverrides: Record<
+        string,
+        {
+          commanderUsed1?: string;
+          commanderUsed2?: string;
+          bracketUsed?: number;
+          deckId?: string;
+          playgroupPlayerDeckId?: string;
+        }
+      > = {};
+
+      for (const p of state.players) {
+        const edit = deckEdits[p.id];
+        if (!edit) continue;
+
+        const overrides: (typeof playerOverrides)[string] = {};
+
+        if (edit.commanderUsed1)
+          overrides.commanderUsed1 = edit.commanderUsed1;
+        if (edit.commanderUsed2)
+          overrides.commanderUsed2 = edit.commanderUsed2;
+        if (edit.bracketUsed)
+          overrides.bracketUsed = parseInt(edit.bracketUsed);
+
+        // Save as new deck if requested
+        if (
+          edit.saveAsNewDeck &&
+          edit.commanderUsed1 &&
+          !p.serverDeckId &&
+          state.playgroupId &&
+          (p.serverUserId || p.serverPlaygroupPlayerId)
+        ) {
+          const saveResult = await saveNewDeckFromGame({
+            playgroupId: state.playgroupId,
+            playerType: p.serverUserId
+              ? "playgroup_member"
+              : "playgroup_player",
+            userId: p.serverUserId,
+            playgroupPlayerId: p.serverPlaygroupPlayerId,
+            format: state.format as MtgFormat,
+            commander1: edit.commanderUsed1,
+            commander2: edit.commanderUsed2 || undefined,
+            bracket: edit.bracketUsed
+              ? parseInt(edit.bracketUsed)
+              : undefined,
+          });
+
+          if ("error" in saveResult) {
+            setError(
+              `Failed to save deck for ${p.name}: ${saveResult.error}`
+            );
+            setSaving(false);
+            return;
+          }
+
+          if (saveResult.deckType === "deck") {
+            overrides.deckId = saveResult.deckId;
+          } else {
+            overrides.playgroupPlayerDeckId = saveResult.deckId;
+          }
+        }
+
+        playerOverrides[p.id] = overrides;
+      }
+
       const createRes = await fetch("/api/v1/games", {
         method: "POST",
         credentials: "same-origin",
@@ -61,25 +157,37 @@ export default function EndGameScreen() {
         body: JSON.stringify({
           format: state.format,
           playgroupId: state.playgroupId,
-          players: state.players.map((p) => ({
-            userId: p.serverUserId || undefined,
-            playgroupPlayerId: p.serverPlaygroupPlayerId || undefined,
-            deckId: p.serverDeckId || undefined,
-            guestName: !p.serverUserId && !p.serverPlaygroupPlayerId ? p.name : undefined,
-            commanderUsed1: p.commanderUsed1 || undefined,
-            commanderUsed2: p.commanderUsed2 || undefined,
-            bracketUsed: p.bracketUsed || undefined,
-          })),
+          players: state.players.map((p) => {
+            const ov = playerOverrides[p.id] || {};
+            return {
+              userId: p.serverUserId || undefined,
+              playgroupPlayerId: p.serverPlaygroupPlayerId || undefined,
+              deckId: ov.deckId || p.serverDeckId || undefined,
+              playgroupPlayerDeckId: ov.playgroupPlayerDeckId || undefined,
+              guestName:
+                !p.serverUserId && !p.serverPlaygroupPlayerId
+                  ? p.name
+                  : undefined,
+              commanderUsed1:
+                ov.commanderUsed1 || p.commanderUsed1 || undefined,
+              commanderUsed2:
+                ov.commanderUsed2 || p.commanderUsed2 || undefined,
+              bracketUsed: ov.bracketUsed ?? p.bracketUsed ?? undefined,
+            };
+          }),
         }),
       });
-      if (!createRes.ok) throw new Error(`Failed to create game (${createRes.status})`);
+      if (!createRes.ok)
+        throw new Error(`Failed to create game (${createRes.status})`);
       const { game } = (await createRes.json()) as {
         game: { id: string; players: { id: string }[] };
       };
 
       let serverWinnerId: string | null = null;
       if (!isDraw && winnerId) {
-        const winnerIndex = state.players.findIndex((p) => p.id === winnerId);
+        const winnerIndex = state.players.findIndex(
+          (p) => p.id === winnerId
+        );
         if (winnerIndex >= 0 && game.players[winnerIndex]) {
           serverWinnerId = game.players[winnerIndex].id;
         }
@@ -95,7 +203,8 @@ export default function EndGameScreen() {
           totalTurns: state.currentTurn,
         }),
       });
-      if (!endRes.ok) throw new Error(`Failed to save result (${endRes.status})`);
+      if (!endRes.ok)
+        throw new Error(`Failed to save result (${endRes.status})`);
 
       endActiveGame();
       router.replace(`/games/${game.id}`);
@@ -159,8 +268,12 @@ export default function EndGameScreen() {
                       : "border-zinc-800 bg-zinc-900 hover:bg-zinc-800",
                   ].join(" ")}
                 >
-                  <span className="flex-1 text-zinc-100 text-base">{player.name}</span>
-                  <span className="text-zinc-400 text-sm mr-3">{player.lifeTotal} life</span>
+                  <span className="flex-1 text-zinc-100 text-base">
+                    {player.name}
+                  </span>
+                  <span className="text-zinc-400 text-sm mr-3">
+                    {player.lifeTotal} life
+                  </span>
                   {winnerId === player.id && (
                     <span className="text-amber-500 text-xl">✓</span>
                   )}
@@ -182,8 +295,55 @@ export default function EndGameScreen() {
                   className="flex justify-between p-3 border-b border-zinc-800"
                 >
                   <span className="text-zinc-500">{player.name}</span>
-                  <span className="text-zinc-500 text-sm">Turn {player.eliminatedTurn}</span>
+                  <span className="text-zinc-500 text-sm">
+                    Turn {player.eliminatedTurn}
+                  </span>
                 </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Deck Info Section */}
+        {showDeckSection && Object.keys(deckEdits).length > 0 && (
+          <section className="mb-6">
+            <h2 className="text-base font-bold text-zinc-400 uppercase tracking-wider mb-3">
+              Deck Info
+            </h2>
+            <p className="text-xs text-zinc-500 mb-3">
+              Add or update the decks used in this game before saving.
+            </p>
+            <div className="space-y-2">
+              {state.players.map((player) => (
+                <PlayerDeckFields
+                  key={player.id}
+                  playerId={player.id}
+                  playerName={player.name}
+                  format={state.format}
+                  deckName={
+                    player.serverDeckId
+                      ? player.commanderUsed1 || "Selected deck"
+                      : null
+                  }
+                  edit={
+                    deckEdits[player.id] || {
+                      commanderUsed1: "",
+                      commanderUsed2: "",
+                      bracketUsed: "",
+                      saveAsNewDeck: false,
+                    }
+                  }
+                  onChange={(edit) =>
+                    setDeckEdits((prev) => ({
+                      ...prev,
+                      [player.id]: edit,
+                    }))
+                  }
+                  canSaveDeck={
+                    !!state.playgroupId &&
+                    !!(player.serverUserId || player.serverPlaygroupPlayerId)
+                  }
+                />
               ))}
             </div>
           </section>
@@ -201,7 +361,7 @@ export default function EndGameScreen() {
           disabled={saving}
           className="w-full py-3 rounded-xl bg-amber-500 text-zinc-950 font-bold text-lg disabled:opacity-60 hover:bg-amber-400 transition-colors"
         >
-          {saving ? "Saving…" : "Save & End Game"}
+          {saving ? "Saving..." : "Save & End Game"}
         </button>
 
         <button

--- a/apps/web/src/components/player-deck-fields.tsx
+++ b/apps/web/src/components/player-deck-fields.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { CardAutocomplete } from "@/components/card-autocomplete";
+import {
+  isCommanderFormat,
+  hasBrackets,
+  EDH_BRACKETS,
+  BRACKET_DESCRIPTIONS,
+  type EdhBracket,
+} from "@/types/mtg";
+
+export type PlayerDeckEdit = {
+  commanderUsed1: string;
+  commanderUsed2: string;
+  bracketUsed: string;
+  saveAsNewDeck: boolean;
+};
+
+type Props = {
+  playerId: string;
+  playerName: string;
+  format: string;
+  deckName?: string | null;
+  edit: PlayerDeckEdit;
+  onChange: (edit: PlayerDeckEdit) => void;
+  /** Whether this player can save a new deck (has userId or playgroupPlayerId) */
+  canSaveDeck: boolean;
+};
+
+export function PlayerDeckFields({
+  playerId,
+  playerName,
+  format,
+  deckName,
+  edit,
+  onChange,
+  canSaveDeck,
+}: Props) {
+  const showCommander = isCommanderFormat(format);
+  const showBracket = hasBrackets(format);
+
+  if (!showCommander && !showBracket) return null;
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-semibold text-zinc-300">{playerName}</span>
+        {deckName && (
+          <span className="text-xs text-amber-500/80 truncate ml-2">
+            {deckName}
+          </span>
+        )}
+      </div>
+
+      {showCommander && (
+        <div className="grid grid-cols-2 gap-3 mb-3">
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">
+              Commander
+            </label>
+            <CardAutocomplete
+              id={`end-cmdr1-${playerId}`}
+              name={`end-cmdr1-${playerId}`}
+              value={edit.commanderUsed1}
+              onChange={(value) =>
+                onChange({ ...edit, commanderUsed1: value })
+              }
+              placeholder="Commander name"
+              commanderOnly={true}
+              showPreview={true}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">
+              Partner (optional)
+            </label>
+            <CardAutocomplete
+              id={`end-cmdr2-${playerId}`}
+              name={`end-cmdr2-${playerId}`}
+              value={edit.commanderUsed2}
+              onChange={(value) =>
+                onChange({ ...edit, commanderUsed2: value })
+              }
+              placeholder="Partner commander"
+              commanderOnly={true}
+              showPreview={true}
+            />
+          </div>
+        </div>
+      )}
+
+      {showBracket && (
+        <div className="mb-3">
+          <label className="block text-xs text-zinc-500 mb-1">
+            EDH Bracket
+          </label>
+          <select
+            value={edit.bracketUsed}
+            onChange={(e) =>
+              onChange({ ...edit, bracketUsed: e.target.value })
+            }
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-amber-500 transition-colors"
+          >
+            <option value="">Select bracket...</option>
+            {EDH_BRACKETS.map((b) => (
+              <option key={b} value={b}>
+                Bracket {b} - {BRACKET_DESCRIPTIONS[b as EdhBracket]}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {showCommander && canSaveDeck && !deckName && edit.commanderUsed1 && (
+        <label className="flex items-center gap-2 text-sm text-zinc-400 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={edit.saveAsNewDeck}
+            onChange={(e) =>
+              onChange({ ...edit, saveAsNewDeck: e.target.checked })
+            }
+            className="rounded border-zinc-600 bg-zinc-800 text-amber-500 focus:ring-amber-500"
+          />
+          Save as new deck for this player
+        </label>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add "Deck Info" section to the live game end screen so players can add/update commanders and brackets before saving
- Add "Deck Info" section to the post-save game edit page for updating commanders and brackets after the fact
- Shared `PlayerDeckFields` component used in both locations
- Supports "save as new deck" checkbox on the end screen for players who entered commanders without a pre-existing deck

## Test plan
- [ ] Start a live game without selecting decks, end it, verify deck info section appears
- [ ] Fill in commander names using autocomplete, save game, verify they appear on game detail
- [ ] Check "save as new deck" for a playgroup player, verify deck is created
- [ ] Edit a saved game, update commanders/brackets, verify changes persist
- [ ] Start a live game with decks pre-selected, verify end screen shows existing deck info pre-populated
- [ ] Verify non-commander formats (e.g. standard) don't show the deck info section

🤖 Generated with [Claude Code](https://claude.com/claude-code)